### PR TITLE
HOCS-2527: specify cluster name

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -6,6 +6,17 @@ export KUBE_SERVER=${KUBE_SERVER}
 export KUBE_TOKEN=${KUBE_TOKEN}
 export VERSION=${VERSION}
 
+if [[ ${KUBE_NAMESPACE} == *prod ]]
+then
+    export MIN_REPLICAS="2"
+    export MAX_REPLICAS="6"
+    export CLUSTER_NAME="acp-prod"
+else
+    export MIN_REPLICAS="1"
+    export MAX_REPLICAS="3"
+    export CLUSTER_NAME="acp-notprod"
+fi
+
 export KUBE_CERTIFICATE_AUTHORITY=/tmp/acp.crt
 if ! curl --silent --fail --retry 5 \
 	https://raw.githubusercontent.com/UKHomeOffice/acp-ca/master/$CLUSTER_NAME.crt -o $KUBE_CERTIFICATE_AUTHORITY; then
@@ -13,16 +24,7 @@ if ! curl --silent --fail --retry 5 \
 	exit 1
 fi
 
-if [[ ${KUBE_NAMESPACE} == *prod ]]
-then
-    export MIN_REPLICAS="2"
-    export MAX_REPLICAS="6"
-else
-    export MIN_REPLICAS="1"
-    export MAX_REPLICAS="3"
-fi
-
-cd kd
+cd kd || exit 1
 
 kd --timeout 15m \
     -f deployment.yaml \


### PR DESCRIPTION
Currently the pipeline is failing because the `$CLUSTER_NAME` is not 
specified. This change enforces that this is specified.