### PR TITLE
HOCS-2239: add downscaler annotation

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -12,11 +12,13 @@ then
     export CASE_CREATOR_UKVI_COMPLAINT_USER="TBD"
     export CASE_CREATOR_UKVI_COMPLAINT_TEAM="TBD"
     export CASE_CREATOR_UKVI_COMPLAINT_GROUP="TBD"
+    export UPTIME_PERIOD="Mon-Sun 05:10-22:50 Europe/London"
 else
     export CLUSTER_NAME="acp-notprod"
     export CASE_CREATOR_UKVI_COMPLAINT_USER="22ca514d-c205-47a0-9e38-68daee4c1299"
     export CASE_CREATOR_UKVI_COMPLAINT_TEAM="08e30ffc-2087-ff3a-b19b-343a88491347"
     export CASE_CREATOR_UKVI_COMPLAINT_GROUP="/COMP_CCH_zqxmzQ6iEkTRw"
+    export UPTIME_PERIOD="Mon-Fri 08:10-17:50 Europe/London"
 fi
 
 export KUBE_CERTIFICATE_AUTHORITY="https://raw.githubusercontent.com/UKHomeOffice/acp-ca/master/${CLUSTER_NAME}.crt"

--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: hocs-case-creator
   labels:
     version: {{.VERSION}}
+  annotations:
+    downscaler/uptime: {{.UPTIME_PERIOD}}
 spec:
   replicas: 1
   strategy:


### PR DESCRIPTION
Presently, when the deployment changes the downscaler annotation 
(that was manually added up to present) gets removed. This causes 
pod to stay up indefinitely, which leads to increased costs and 
potential issues. This change enforced the uptime meta-data 
annotation that enforces this server stays up. This is specified 
differently depending on if we are in prod or notprod.